### PR TITLE
Add support for Steam's new Workshop SPA

### DIFF
--- a/content.js
+++ b/content.js
@@ -3,18 +3,21 @@ let isHidingSubscribed = false;
 let currentStarFilter = 0; // 0 means show all
 
 function createButtons() {
-    const controlArea = document.querySelector('.workshop_browse_menu_area, .workshop_browse_options, .collectionControls>.workshopItemControls');
+    const controlArea = document.querySelector('.workshop_browse_menu_area, .workshop_browse_options, .collectionControls>.workshopItemControls')
+        || document.querySelector('a[href*="/workshop/about/"]')?.parentElement;
     if (!controlArea || document.querySelector('.hide-subscribed-button')) return;
+
+    document.querySelectorAll('.star-dropdown-content').forEach(el => el.remove());
 
     // Create star filter dropdown button
     const starFilterContainer = document.createElement('div');
     starFilterContainer.style.display = 'inline-block';
     starFilterContainer.style.position = 'relative';
-    
+
     const starButton = document.createElement('button');
     starButton.className = 'hide-subscribed-button star-filter-button';
     starButton.textContent = 'Star Rating ▼';
-    
+
     const dropdownContent = document.createElement('div');
     dropdownContent.className = 'star-dropdown-content';
     dropdownContent.innerHTML = `
@@ -35,6 +38,12 @@ function createButtons() {
     // Add event listeners for star filter
     starButton.addEventListener('click', (e) => {
         e.stopPropagation();
+        const isOpening = !dropdownContent.classList.contains('show');
+        if (isOpening) {
+            const rect = starButton.getBoundingClientRect();
+            dropdownContent.style.top = `${rect.bottom}px`;
+            dropdownContent.style.left = `${rect.left}px`;
+        }
         dropdownContent.classList.toggle('show');
     });
 
@@ -45,10 +54,10 @@ function createButtons() {
             currentStarFilter = parseInt(option.dataset.stars);
             starButton.textContent = `${currentStarFilter === 0 ? 'Star Rating ▼' : currentStarFilter + '+ Stars ▼'}`;
             dropdownContent.classList.remove('show');
-            
+
             // Save star filter preference
             chrome.storage.local.set({ starFilter: currentStarFilter });
-            
+
             applyFilters();
         }
     });
@@ -80,15 +89,16 @@ function createButtons() {
     });
 
     starFilterContainer.appendChild(starButton);
-    starFilterContainer.appendChild(dropdownContent);
+    document.body.appendChild(dropdownContent);
     controlArea.appendChild(starFilterContainer);
     controlArea.appendChild(hideButton);
 }
 
 function getStarRating(item) {
     const ratingImg = item.querySelector('.fileRating');
-    if (!ratingImg) return 0;
-    
+
+    if (!ratingImg) return item.querySelectorAll('.SVGIcon_Star_Filled').length;
+
     // Extract star rating from image source
     const src = ratingImg.src;
     if (src.includes('5-star')) return 5;
@@ -96,12 +106,12 @@ function getStarRating(item) {
     if (src.includes('3-star')) return 3;
     if (src.includes('2-star')) return 2;
     if (src.includes('1-star')) return 1;
-    
+
     // Alternative method using data attribute if available
     if (ratingImg.dataset.rating) {
         return parseInt(ratingImg.dataset.rating);
     }
-    
+
     return 0;
 }
 
@@ -116,19 +126,36 @@ function isSubscribed(item) {
         return true;
     }
 
+    if (item.querySelector('.SVGIcon_Check')) {
+        return true;
+    }
+
     return false;
+}
+
+function getSpaCards() {
+    const cards = new Set();
+    document.querySelectorAll('a[href*="/sharedfiles/filedetails/?id="]').forEach(anchor => {
+        const card = anchor.closest('.Panel');
+        if (card && card.querySelector('.SVGIcon_Star_Filled, .SVGIcon_Star_Unfilled')) {
+            cards.add(card);
+        }
+    });
+    return cards;
 }
 
 function applyFilters() {
     const selectors = [
         '.collectionItem',
-        '.workshopItemCollection', 
+        '.workshopItemCollection',
         '.workshopItem'
     ];
 
-    const itemsToFilter = selectors
+    const classicItems = selectors
         .map(selector => document.querySelectorAll(selector))
-        .find(elements => elements.length > 0) || document.querySelectorAll(selectors[2]);
+        .find(elements => elements.length > 0);
+
+    const itemsToFilter = classicItems || getSpaCards();
 
     Array.from(itemsToFilter).forEach(item => {
         const starRating = getStarRating(item);
@@ -143,9 +170,9 @@ function applyFilters() {
 function toggleSubscribedItems() {
     const button = document.querySelector('.hide-subscribed-button:not(.star-filter-button)');
     isHidingSubscribed = !isHidingSubscribed;
-    
+
     chrome.storage.local.set({ hideSubscribed: isHidingSubscribed });
-    
+
     if (isHidingSubscribed) {
         button.classList.add('active');
         button.textContent = 'Showing New Items';
@@ -153,7 +180,7 @@ function toggleSubscribedItems() {
         button.classList.remove('active');
         button.textContent = 'Hide Subscribed';
     }
-    
+
     applyFilters();
 }
 
@@ -181,10 +208,21 @@ function init() {
 }
 
 // Set up mutation observer to handle dynamically loaded content
+let debounceTimer = null;
+
+function scheduleApplyFilters() {
+    if (debounceTimer) return;
+    debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        applyFiltersIfNeeded();
+    }, 150);
+}
+
 const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
         if (mutation.addedNodes.length) {
-            applyFiltersIfNeeded();
+            scheduleApplyFilters();
+            return;
         }
     }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Steam Workshop Filter Plus",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Filter Steam Workshop content by hiding subscribed items and filtering by star rating. Find new, high-quality content more easily.",
     "icons": {
         "128": "Steam-Workshop-Filter-Plus-Icon.png"
@@ -11,6 +11,7 @@
         {
             "matches": [
                 "*://*.steamcommunity.com/workshop/*",
+                "*://*.steamcommunity.com/app/*/workshop/*",
                 "*://*.steamcommunity.com/sharedfiles/filedetails/*"
             ],
             "js": ["content.js"],

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,13 @@ dcave14 - [GitHub Profile](https://github.com/dcave14)
 
 ## Changelog
 
+### 1.3.0
+- Added support for Steam's new Workshop SPA (`/app/{id}/workshop/`)
+- Buttons now inject into the new navigation panel next to "About"
+- Star rating and subscription state detected via stable SVG icons on the new cards
+- Fixed the star filter dropdown rendering behind Steam's item cards
+- Debounced re-injection to handle the SPA's client-side re-renders
+
 ### 1.2.0
 - Added support for multiple item types (collection, workshop item, etc.)
 - Improved filter logic to handle different item structures

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,7 @@
     margin-left: 10px;
     padding: 5px 10px;
     transition: all 0.2s ease;
+    vertical-align: middle;
 }
 
 .hide-subscribed-button.active {
@@ -26,15 +27,13 @@
 
 .star-dropdown-content {
     display: none;
-    position: absolute;
+    position: fixed;
     background-color: #171a21;
     min-width: 160px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-    z-index: 1000;
+    z-index: 2147483647;
     border: 1px solid #4d4d4d;
     border-radius: 2px;
-    top: 100%;
-    left: 0;
 }
 
 .star-dropdown-content.show {


### PR DESCRIPTION
## Problem

Steam rebuilt the Workshop sections (`/app/{id}/workshop/` and `/workshop/browse/`) as a React-style SPA with obfuscated CSS class names that change on every build. This broke **all** of the extension's selectors on those pages: it could no longer find the button container, the items, the rating, or the subscription state. Classic collection / `sharedfiles/filedetails` pages were unaffected.

## Approach

The obfuscated classes can't be used as selectors (they change each deploy), so the extension is re-anchored on **stable hooks** confirmed against the live DOM, while keeping the classic path untouched:

| Need | Stable hook |
|---|---|
| Nav panel (where buttons go) | `a[href*="/workshop/about/"]` → `parentElement` |
| Item card | `a[href*="/sharedfiles/filedetails/?id="]` → `closest('.Panel')` |
| Rating (0–5) | count `.SVGIcon_Star_Filled` in the card |
| Subscribed | presence of `.SVGIcon_Check` |

## Changes

- **manifest:** match `*://*.steamcommunity.com/app/*/workshop/*` and bump version to `1.3.0`.
- **createButtons:** fall back to the SPA nav panel (anchored by the About link) when the classic control area is absent. Buttons land next to *About*.
- **getStarRating:** count `.SVGIcon_Star_Filled` when `.fileRating` is absent.
- **isSubscribed:** detect `.SVGIcon_Check` on the new cards.
- **applyFilters:** build the SPA card list from the filedetails anchors → `.Panel` (deduped, skipping panels without stars), falling back only when no classic items exist.
- **dropdown:** render the star dropdown in `<body>` with `position: fixed` so it's no longer painted behind Steam's item cards.
- **MutationObserver:** debounce re-injection to handle the SPA's frequent client-side re-renders.

## Testing

Loaded unpacked and verified on `steamcommunity.com/app/108600/workshop/` (logged in): both buttons appear next to *About*, *Hide Subscribed* hides cards with `SVGIcon_Check`, the star filter hides cards below the threshold, and preferences persist across reloads. Classic collection pages continue to work with no regression.